### PR TITLE
Fix typespecs

### DIFF
--- a/lib/system_registry.ex
+++ b/lib/system_registry.ex
@@ -65,15 +65,13 @@ defmodule SystemRegistry do
       iex>  SystemRegistry.update([:a, :b], 1)
       {:ok, {%{a: %{b: 1}}, %{}}}
   """
-  # @spec update(Transaction.t | scope, scope | value :: term, value :: term) :: {:ok, {new :: map, old :: map}} | {:error, term}
-  # @spec update(Transaction.t | [term], [term] | any, Keyword.t | any) :: Transaction.t | {:ok, {new :: map, old :: map}} | {:error, term}
   @spec update(one, scope, value :: any) :: Transaction.t when one: Transaction.t
   def update(_, _, _ \\ nil)
   def update(%Transaction{} = t, scope, value) when not is_nil(scope) do
     Transaction.update(t, scope, value)
   end
 
-  @spec update(one, value :: any, opts :: Keyword.t) :: {:ok, {new :: map, old :: map}} | {:error, term} when one: [term]
+  @spec update(one, value :: any, opts :: Keyword.t) :: {:ok, {new :: map, old :: map}} | {:error, term} when one: scope
   def update(scope, value, opts) do
     transaction(opts)
     |> update(scope, value)
@@ -117,13 +115,13 @@ defmodule SystemRegistry do
       iex> SystemRegistry.transaction |> SystemRegistry.move([:a], [:b]) |> SystemRegistry.commit
       {:ok, {%{b: 1}, %{a: 1}}}
   """
-  # @spec move(Transaction.t, old_scope, new_scope) ::
-  #   {:ok, {new :: map, old :: map}} | {:error, term}
+  @spec move(transaction, scope, scope) :: Transaction.t when transaction: Transaction.t
   def move(_, _, _ \\ nil)
   def move(%Transaction{} = t, old_scope, new_scope) when not is_nil(new_scope) do
     Transaction.move(t, old_scope, new_scope)
   end
 
+  @spec move(scope_arg, scope, opts :: nil | Keyword.t) :: {:ok, {new :: map, old :: map}} | {:error, term} when scope_arg: scope
   def move(old_scope, new_scope, opts) do
     transaction(opts)
     |> move(old_scope, new_scope)
@@ -156,11 +154,13 @@ defmodule SystemRegistry do
       {:ok, {%{}, %{a: %{b: 1}}}}
 
   """
+  @spec delete(transaction, scope) :: Transaction.t when transaction: Transaction.t
   def delete(_, _ \\ nil)
   def delete(%Transaction{} = t, scope) when not is_nil(scope) do
     Transaction.delete(t, scope)
   end
 
+  @spec delete(scope, Keyword.t | nil) :: {:ok, {new :: map, old :: map}} | {:error, term}
   def delete(scope, opts) do
     opts = opts || []
     transaction(opts)

--- a/lib/system_registry/processor.ex
+++ b/lib/system_registry/processor.ex
@@ -1,10 +1,12 @@
 defmodule SystemRegistry.Processor do
 
-  @callback handle_validate(Transaction.t, state :: term) ::
-    {:ok, Transaction.t} | {:error, term}
+  @doc "Handles a validation. Takes a transaction, and returns {:ok, reply, state} or {:error, reason, state}."
+  @callback handle_validate(SystemRegistry.Transaction.t, state :: term) ::
+    {:ok, term, state :: term} | {:error, reason :: term, state :: term}
 
-  @callback handle_commit(Transaction.t, state :: term) ::
-    {:ok, Transaction.t} | {:error, term}
+  @doc "Handles a commit. Takes a transaction and returns {:ok, reply, state} | {:error, reason, state}."
+  @callback handle_commit(SystemRegistry.Transaction.t, state :: term) ::
+    {:ok, term, state :: term} | {:error, reason :: term, state :: term}
 
   defmacro __using__(_opts) do
     quote do


### PR DESCRIPTION
* SystemRegistry.Processor behaviour was wrong.
* Inferred types for SystemRegistry api was wrong.

NOTE: 
on Elixir 1.5.0 `mix dialyzer` will give an error: 
```
lib/system_registry/processor/config.ex:90: The created fun has no local return
lib/system_registry/processor/config.ex:92: The call 'Elixir.Registry':match('Elixir.SystemRegistry.Storage.State',pid@1::any(),#{_=>#{}}) will never return since it differs in the 3rd argument from the success typing arguments: (atom(),any(),atom() | tuple())
```

This since been fixed in upstream Elixir, just not pushed to a stable release yet.