### PR TITLE
all calls to system registry genservers should not time out

### DIFF
--- a/lib/system_registry.ex
+++ b/lib/system_registry.ex
@@ -38,7 +38,7 @@ defmodule SystemRegistry do
   @spec commit(Transaction.t) ::
     {:ok, {new :: map, old :: map}} | {:error, term}
   def commit(transaction) do
-    GenServer.call(Local, {:commit, transaction})
+    GenServer.call(Local, {:commit, transaction}, :infinity)
   end
 
   @doc """
@@ -95,7 +95,7 @@ defmodule SystemRegistry do
     {:ok, {new :: map, old :: map}} | {:error, term}
   def update_in(scope, fun, opts \\ []) do
     t = Transaction.begin(opts)
-    GenServer.call(Local, {:update_in, t, scope, fun})
+    GenServer.call(Local, {:update_in, t, scope, fun}, :infinity)
   end
 
   @doc """
@@ -182,7 +182,7 @@ defmodule SystemRegistry do
   @spec delete_all(pid | nil) ::
     {:ok, {new :: map, old :: map}} | {:error, term}
   def delete_all(pid \\ nil) do
-    GenServer.call(Local, {:delete_all, (pid || self())})
+    GenServer.call(Local, {:delete_all, (pid || self())}, :infinity)
   end
 
   @doc """

--- a/lib/system_registry/global.ex
+++ b/lib/system_registry/global.ex
@@ -9,15 +9,15 @@ defmodule SystemRegistry.Global do
   end
 
   def put(scope, value) do
-    GenServer.call(__MODULE__, {:put, scope, value})
+    GenServer.call(__MODULE__, {:put, scope, value}, :infinity)
   end
 
   def apply_updates(updates, nodes) do
-    GenServer.call(__MODULE__, {:update, updates, nodes})
+    GenServer.call(__MODULE__, {:update, updates, nodes}, :infinity)
   end
 
   def apply_deletes(deletes, nodes) do
-    GenServer.call(__MODULE__, {:delete, deletes, nodes})
+    GenServer.call(__MODULE__, {:delete, deletes, nodes}, :infinity)
   end
 
   def init(_) do

--- a/lib/system_registry/local.ex
+++ b/lib/system_registry/local.ex
@@ -14,7 +14,7 @@ defmodule SystemRegistry.Local do
   end
 
   def register_processor({mod, pid}) do
-    GenServer.call(__MODULE__, {:register_processor, {mod, pid}})
+    GenServer.call(__MODULE__, {:register_processor, {mod, pid}}, :infinity)
   end
 
   # GenServer API

--- a/lib/system_registry/processor.ex
+++ b/lib/system_registry/processor.ex
@@ -18,11 +18,11 @@ defmodule SystemRegistry.Processor do
       end
 
       def validate(pid, transaction) do
-        GenServer.call(pid, {:validate, transaction})
+        GenServer.call(pid, {:validate, transaction}, :infinity)
       end
 
       def commit(pid, transaction) do
-        GenServer.call(pid, {:commit, transaction})
+        GenServer.call(pid, {:commit, transaction}, :infinity)
       end
 
       def init(opts) do

--- a/lib/system_registry/processor/config.ex
+++ b/lib/system_registry/processor/config.ex
@@ -10,7 +10,7 @@ defmodule SystemRegistry.Processor.Config do
   import SystemRegistry.Utils
 
   def put_priorities(priorities) do
-    GenServer.call(__MODULE__, {:put_priorities, priorities})
+    GenServer.call(__MODULE__, {:put_priorities, priorities}, :infinity)
   end
 
   def init(opts) do

--- a/lib/system_registry/registration.ex
+++ b/lib/system_registry/registration.ex
@@ -25,19 +25,19 @@ defmodule SystemRegistry.Registration do
   end
 
   def register(pid \\ nil, opts) do
-    GenServer.call(__MODULE__, {:register, (pid || self()), opts})
+    GenServer.call(__MODULE__, {:register, (pid || self()), opts}, :infinity)
   end
 
   def unregister(pid \\ nil, key) do
-    GenServer.call(__MODULE__, {:unregister, (pid || self()), key})
+    GenServer.call(__MODULE__, {:unregister, (pid || self()), key}, :infinity)
   end
 
   def unregister_all(pid \\ nil) do
-    GenServer.call(__MODULE__, {:unregister, (pid || self())})
+    GenServer.call(__MODULE__, {:unregister, (pid || self())}, :infinity)
   end
 
   def notify(key, value) do
-    GenServer.call(__MODULE__, {:notify, key, value})
+    GenServer.call(__MODULE__, {:notify, key, value}, :infinity)
   end
 
   # GenServer API


### PR DESCRIPTION
SystemRegistry is intended to be serial and eventually consistent, therefore, all calls to persist data should take as long as they need to succeed.

While debugging an issue connected to system_registry, I've noticed that when it is under heavy load, calls to persist data in the registry were timing out and thus crashing unrelated parts of the supervision tree.