### PR TITLE
SR.update/3 spec fix: The 3rd parameter can be nil.

### DIFF
--- a/lib/system_registry.ex
+++ b/lib/system_registry.ex
@@ -81,7 +81,7 @@ defmodule SystemRegistry do
     Transaction.update(t, scope, value)
   end
 
-  @spec update(one, value :: any, opts :: Keyword.t()) ::
+  @spec update(one, value :: any, opts :: nil | Keyword.t()) ::
           {:ok, {new :: map, old :: map}} | {:error, term}
         when one: scope
   def update(scope, value, opts) do


### PR DESCRIPTION
[My first serious encounter with @spec](https://elixirforum.com/t/confused-about-spec-dialyxir-invalid-type-specification-for-function/16374) resulted in finding a bug both in Dialyxir and in SystemRegistry.

Luckily, the fix to SystemRegistry is trivial.