### PR TITLE
Prevent get_in from raising an exception.

### DIFF
--- a/lib/system_registry/application.ex
+++ b/lib/system_registry/application.ex
@@ -7,6 +7,7 @@ defmodule SystemRegistry.Application do
 
   def start(_type, _args) do
     partitions = System.schedulers_online()
+
     registries =
       Enum.map([Registration, Binding, State], fn reg ->
         reg = Module.concat(SystemRegistry.Storage, reg)

--- a/lib/system_registry/processor/state.ex
+++ b/lib/system_registry/processor/state.ex
@@ -25,22 +25,26 @@ defmodule SystemRegistry.Processor.State do
     leaf_reserved =
       Node.leaf_nodes(t.updates)
       |> Enum.reduce([], fn scope, reserved ->
-        case get_in(global, scope) do
-          nil ->
-            reserved
-
-          map ->
-            frag_reserved =
-              Transaction.scope(scope, map)
-              |> Node.leaf_nodes()
-              |> Enum.map(&%Node{node: &1})
-              |> permissions(t.pid)
-
-            if frag_reserved == [] do
+        try do
+          case get_in(global, scope) do
+            nil ->
               reserved
-            else
-              [scope | reserved]
-            end
+
+            map ->
+              frag_reserved =
+                Transaction.scope(scope, map)
+                |> Node.leaf_nodes()
+                |> Enum.map(&%Node{node: &1})
+                |> permissions(t.pid)
+
+              if frag_reserved == [] do
+                reserved
+              else
+                [scope | reserved]
+              end
+          end
+        rescue
+          _e -> reserved
         end
       end)
 

--- a/lib/system_registry/transaction.ex
+++ b/lib/system_registry/transaction.ex
@@ -173,16 +173,21 @@ defmodule SystemRegistry.Transaction do
     prune =
       Node.leaf_nodes(t.updates)
       |> Enum.reduce([], fn scope, deletes ->
-        case get_in(local, scope) do
-          nil ->
+        try do
+          case get_in(local, scope) do
+            nil ->
+              deletes
+
+            map ->
+              scopes =
+                scope(scope, map)
+                |> Node.leaf_nodes()
+
+              deletes ++ scopes
+          end
+        rescue
+          _e ->
             deletes
-
-          map ->
-            scopes =
-              scope(scope, map)
-              |> Node.leaf_nodes()
-
-            deletes ++ scopes
         end
       end)
 


### PR DESCRIPTION
Kernel.get_in will raise when trying to recurse a data structure if it encounters a type that does not implement the access protocol. 

Here is an example:

```elixir
get_in(%{"a" => 1}, ["a", "b"])
```

This will produce:

```elixir
** (FunctionClauseError) no function clause matching in Access.get/3

    The following arguments were given to Access.get/3:

        # 1
        1

        # 2
        "b"

        # 3
        nil

    Attempted function clauses (showing 5 out of 5):

        def get(%module{} = container, key, default)
        def get(map, key, default) when is_map(map)
        def get(list, key, default) when is_list(list) and is_atom(key)
        def get(list, key, _default) when is_list(list)
        def get(nil, _key, default)

    (elixir) lib/access.ex:316: Access.get/3
```
