### PR TITLE
Fix documentation errors and formatting

### DIFF
--- a/lib/system_registry/node.ex
+++ b/lib/system_registry/node.ex
@@ -40,14 +40,15 @@ defmodule SystemRegistry.Node do
 
   ## Examples
 
-    iex> SystemRegistry.Node.leaf_nodes(%{a: 2})
-    [[:a]]
+      iex> SystemRegistry.Node.leaf_nodes(%{a: 2})
+      [[:a]]
 
-    iex> SystemRegistry.Node.leaf_nodes(%{a: %{b: 1, c: %{d: 2}}})
-    [[:a, :b], [:a, :c, :d]]
+      iex> SystemRegistry.Node.leaf_nodes(%{a: %{b: 1, c: %{d: 2}}})
+      [[:a, :b], [:a, :c, :d]]
 
-    iex> SystemRegistry.Node.leaf_nodes(%{})
-    []
+      iex> SystemRegistry.Node.leaf_nodes(%{})
+      []
+
   """
   def leaf_nodes(map) do
     leaf_nodes([], map)

--- a/lib/system_registry/processor.ex
+++ b/lib/system_registry/processor.ex
@@ -1,9 +1,9 @@
 defmodule SystemRegistry.Processor do
-  @doc "Handles a validation. Takes a transaction, and returns {:ok, reply, state} or {:error, reason, state}."
+  @doc "Handles a validation. Takes a transaction, and returns `{:ok, reply, state}` or `{:error, reason, state}`."
   @callback handle_validate(SystemRegistry.Transaction.t(), state :: term) ::
               {:ok, term, state :: term} | {:error, reason :: term, state :: term}
 
-  @doc "Handles a commit. Takes a transaction and returns {:ok, reply, state} | {:error, reason, state}."
+  @doc "Handles a commit. Takes a transaction and returns `{:ok, reply, state}` or `{:error, reason, state}`."
   @callback handle_commit(SystemRegistry.Transaction.t(), state :: term) ::
               {:ok, term, state :: term} | {:error, reason :: term, state :: term}
 

--- a/lib/system_registry/task.ex
+++ b/lib/system_registry/task.ex
@@ -1,21 +1,21 @@
 defmodule SystemRegistry.Task do
   @moduledoc """
-
   Creates a process that executes a function anytime the contents of a given
-  system_registry scope change.
+  `SystemRegistry` scope change.
 
   For example, to perform an operation every time that the IPv4 address changes
-  on "wlan0", do this:
+  on `"wlan0"`, do this:
 
-    {SystemRegistry.Task, [
-      [:state, :network_interface,  "wlan0", :ipv4_address],
-      fn({_old, _new}) ->
-        # Do something
-      end]}
+      {SystemRegistry.Task,
+       [
+         [:state, :network_interface, "wlan0", :ipv4_address],
+         fn {_old, _new} ->
+           # Do something
+         end
+       ]}
 
   This technique should be used sparingly and only for performing simple side
   effects to state change. 
-
   """
 
   use GenServer

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule SystemRegistry.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env()),
       description: description(),
       package: package(),
+      source_url: "https://github.com/nerves-project/system_registry",
       docs: docs(),
       deps: deps()
     ]


### PR DESCRIPTION
Applied documentation best practices, including but not limited to:

- proper indentation
- using headers to denote example and option sections
- referencing functions by arity and with backticks
- namespacing references so that links are generated
- running the formatter on some of the code samples
- added source_url so that links to the repo are generated

Fixed spelling and punctuation errors. Also some minor content edits
to improve readability.